### PR TITLE
update unshare to support creating persistent files

### DIFF
--- a/hrr_rb_lxns.gemspec
+++ b/hrr_rb_lxns.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/hrr_rb_lxns/extconf.rb"]
+
+  spec.add_dependency "hrr_rb_mount", ">= 0.3.0"
 end

--- a/lib/hrr_rb_lxns.rb
+++ b/lib/hrr_rb_lxns.rb
@@ -48,9 +48,28 @@ module HrrRbLxns
   # @raise [Errno::EXXX] In case unshare(2) system call failed.
   def self.unshare flags, options={}
     _flags = interpret_flags flags
-    ret = __unshare__ _flags
-    bind_ns_files _flags, options
-    ret
+    io = nil
+    child_pid = nil
+    begin
+      io = IO.pipe
+      child_pid = bind_ns_files_from_child _flags, options, io
+      ret = __unshare__ _flags
+      bind_ns_files _flags, options, child_pid, io
+      ret
+    ensure
+      if io
+        io_r, io_w = io
+        io_w.write "1" rescue nil # just in case "mnt" flag is set but gets an error before io_w.write in bind_ns_files
+        io_w.close     rescue nil
+        io_r.close     rescue nil
+      end
+      if child_pid
+        begin
+          Process.waitpid child_pid
+        rescue Errno::ECHILD
+        end
+      end
+    end
   end
 
   # A wrapper around setns(2) system call.
@@ -130,20 +149,50 @@ module HrrRbLxns
     end
   end
 
-  def self.bind_ns_files flags, options
-    list = Array.new
-    list.push ["ipc",    NEWIPC,    :ipc    ] if const_defined?(:NEWIPC)
-    list.push ["mnt",    NEWNS,     :mount  ] if const_defined?(:NEWNS)
-    list.push ["net",    NEWNET,    :network] if const_defined?(:NEWNET)
-    list.push ["pid",    NEWPID,    :pid    ] if const_defined?(:NEWPID)
-    list.push ["uts",    NEWUTS,    :uts    ] if const_defined?(:NEWUTS)
-    list.push ["user",   NEWUSER,   :user   ] if const_defined?(:NEWUSER)
-    list.push ["cgroup", NEWCGROUP, :cgroup ] if const_defined?(:NEWCGROUP)
-    list.push ["time",   NEWTIME,   :time   ] if const_defined?(:NEWTIME)
-    pid = "self"
-    list.each do |name, flag, key|
-      if (flags & flag).zero?.! && options[key]
-        HrrRbMount.bind "/proc/#{pid}/ns/#{name}", options[key]
+  # In some cases, namespace files need to be created by an external process.
+  # Thus, this method calls fork and the child process creates the namespace files.
+  def self.bind_ns_files_from_child flags, options, io
+    ppid = Process.pid
+    io_r, io_w = io
+    if pid = fork
+      pid
+    else
+      exit_status = true
+      begin
+        io_r.read 1
+        bind_ns_files flags, options, nil, nil, ppid
+      rescue Exception => e
+        exit_status = false
+        io_w.write Marshal.dump(e)
+      ensure
+        exit! exit_status
+      end
+    end
+  end
+
+  def self.bind_ns_files flags, options, child_pid, io, pid="self"
+    if child_pid
+      io_r, io_w = io
+      io_w.write "1"
+      io_w.close rescue nil
+      _, status = Process.waitpid2 child_pid
+      if status.exitstatus != 0
+        raise Marshal.load(io_r.read)
+      end
+    else
+      list = Array.new
+      list.push ["ipc",    NEWIPC,    :ipc    ] if const_defined?(:NEWIPC)
+      list.push ["mnt",    NEWNS,     :mount  ] if const_defined?(:NEWNS)
+      list.push ["net",    NEWNET,    :network] if const_defined?(:NEWNET)
+      list.push ["pid",    NEWPID,    :pid    ] if const_defined?(:NEWPID) # TODO: pid namespace must be bind-mounted against the child process's
+      list.push ["uts",    NEWUTS,    :uts    ] if const_defined?(:NEWUTS)
+      list.push ["user",   NEWUSER,   :user   ] if const_defined?(:NEWUSER)
+      list.push ["cgroup", NEWCGROUP, :cgroup ] if const_defined?(:NEWCGROUP)
+      list.push ["time",   NEWTIME,   :time   ] if const_defined?(:NEWTIME)
+      list.each do |name, flag, key|
+        if (flags & flag).zero?.! && options[key]
+          HrrRbMount.bind "/proc/#{pid}/ns/#{name}", options[key]
+        end
       end
     end
   end


### PR DESCRIPTION
The PR updates unshare operation to support creating bind-mounted persistent namespaces files.