### PR TITLE
update unshare to support :fork option for PID namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ File.readlink "/proc/self/ns/mnt"   # => mnt:[yyy]
 
 HrrRbLxns.unshare supports creating persistent namespaces files by bind-mount. The files are specified in an options hash. The keys which are available in the hash for each namespace are `:mount`, `:uts`, `:ipc`, `:network`, `:pid`, `:user`, `:cgroup`, and `:time`.
 Note that files that namespaces are bind-mounted must exist. The library does just bind-mount, not create the files. And the files and their mount information are kept after the caller process is finished.
+When unsharing pid namespace, the namespace file should be bind-mounted against the caller's child process. For this case, `:fork` option is supported.
 
 ```ruby
 File.readlink "/proc/self/ns/uts"            # => uts:[aaa]
@@ -63,6 +64,18 @@ HrrRbMount.make_private "/path/to/myns"
 FileUtils.touch "/path/to/myns/mnt"
 options = {:mount => "/path/to/myns/mnt"}
 HrrRbLxns.unshare HrrRbLxns::NEWNS, options # => 0
+
+# For pid namespace, :fork option is available
+options = {:pid => "/path/to/myns/pid", :fork => true}
+# .unshare method with :fork option works like Kernel.#fork after unshare(2)
+if pid = HrrRbLxns.unshare HrrRbLxns::NEWPID, options
+  # In parent, .unshare returns the child process's PID (In this case, it is 1 because unsharing PID namespace)
+  # Do something
+  Process.waitpid pid
+else
+  # In child, .unshare returns nil
+  # Do something
+end
 ```
 
 ### Setns

--- a/spec/hrr_rb_lxns_spec.rb
+++ b/spec/hrr_rb_lxns_spec.rb
@@ -243,20 +243,56 @@ RSpec.describe HrrRbLxns do
                     expect{ HrrRbLxns.unshare flags, options }.to raise_error SystemCallError
                   end
                 else
-                  it "disassociates #{targets.inspect} namespaces and bind-mounts them" do
-                    options = Hash.new
-                    targets.each do |key|
-                      options[namespaces[key][:key]] = @persist_files[key].path
+                  if targets.include? "pid"
+                    context "without :fork option" do
+                      it "disassociates #{targets.inspect} namespaces and bind-mounts them except for pid" do
+                        options = Hash.new
+                        targets.each do |key|
+                          options[namespaces[key][:key]] = @persist_files[key].path
+                        end
+                        targets.each{ |ns|
+                          before = File.stat("/proc/self/ns/#{ns}").ino
+                          after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
+                          expect( after ).not_to eq before
+                          expect( HrrRbMount.mountpoint?(@persist_files[ns].path) ).to be true
+                          if ns == "pid"
+                            expect( File.stat(@persist_files[ns].path).ino ).to_not eq after
+                          else
+                            expect( File.stat(@persist_files[ns].path).ino ).to eq after
+                          end
+                        }
+                      end
                     end
-                    targets.each{ |ns|
-                      before = File.stat("/proc/self/ns/#{ns}").ino
-                      after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
-                      expect( after ).not_to eq before
-                      if ns != "pid"
+                    context "with :fork option" do
+                      it "disassociates #{targets.inspect} namespaces and bind-mounts them (pid_for_children for pid)" do
+                        options = Hash.new
+                        targets.each do |key|
+                          options[namespaces[key][:key]] = @persist_files[key].path
+                        end
+                        options[:fork] = true
+                        targets.each{ |ns|
+                          before = File.stat("/proc/self/ns/#{ns}").ino
+                          after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
+                          expect( after ).not_to eq before
+                          expect( HrrRbMount.mountpoint?(@persist_files[ns].path) ).to be true
+                          expect( File.stat(@persist_files[ns].path).ino ).to eq after
+                        }
+                      end
+                    end
+                  else
+                    it "disassociates #{targets.inspect} namespaces and bind-mounts them" do
+                      options = Hash.new
+                      targets.each do |key|
+                        options[namespaces[key][:key]] = @persist_files[key].path
+                      end
+                      targets.each{ |ns|
+                        before = File.stat("/proc/self/ns/#{ns}").ino
+                        after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
+                        expect( after ).not_to eq before
                         expect( HrrRbMount.mountpoint?(@persist_files[ns].path) ).to be true
                         expect( File.stat(@persist_files[ns].path).ino ).to eq after
-                      end
-                    }
+                      }
+                    end
                   end
                 end
               end
@@ -305,20 +341,56 @@ RSpec.describe HrrRbLxns do
                     expect{ HrrRbLxns.unshare flags, options }.to raise_error SystemCallError
                   end
                 else
-                  it "disassociates #{targets.inspect} namespaces and bind-mounts them" do
-                    options = Hash.new
-                    targets.each do |key|
-                      options[namespaces[key][:key]] = @persist_files[key].path
+                  if targets.include? "pid"
+                    context "without :fork option" do
+                      it "disassociates #{targets.inspect} namespaces and bind-mounts them except for pid" do
+                        options = Hash.new
+                        targets.each do |key|
+                          options[namespaces[key][:key]] = @persist_files[key].path
+                        end
+                        targets.each{ |ns|
+                          before = File.stat("/proc/self/ns/#{ns}").ino
+                          after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
+                          expect( after ).not_to eq before
+                          expect( HrrRbMount.mountpoint?(@persist_files[ns].path) ).to be true
+                          if ns == "pid"
+                            expect( File.stat(@persist_files[ns].path).ino ).to_not eq after
+                          else
+                            expect( File.stat(@persist_files[ns].path).ino ).to eq after
+                          end
+                        }
+                      end
                     end
-                    targets.each{ |ns|
-                      before = File.stat("/proc/self/ns/#{ns}").ino
-                      after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
-                      expect( after ).not_to eq before
-                      if ns != "pid"
+                    context "with :fork option" do
+                      it "disassociates #{targets.inspect} namespaces and bind-mounts them (pid_for_children for pid)" do
+                        options = Hash.new
+                        targets.each do |key|
+                          options[namespaces[key][:key]] = @persist_files[key].path
+                        end
+                        options[:fork] = true
+                        targets.each{ |ns|
+                          before = File.stat("/proc/self/ns/#{ns}").ino
+                          after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
+                          expect( after ).not_to eq before
+                          expect( HrrRbMount.mountpoint?(@persist_files[ns].path) ).to be true
+                          expect( File.stat(@persist_files[ns].path).ino ).to eq after
+                        }
+                      end
+                    end
+                  else
+                    it "disassociates #{targets.inspect} namespaces and bind-mounts them" do
+                      options = Hash.new
+                      targets.each do |key|
+                        options[namespaces[key][:key]] = @persist_files[key].path
+                      end
+                      targets.each{ |ns|
+                        before = File.stat("/proc/self/ns/#{ns}").ino
+                        after = namespaces[ns][:func1].call lambda{ HrrRbLxns.unshare flags, options }, lambda{ File.stat("/proc/self/ns/#{ns}").ino }
+                        expect( after ).not_to eq before
                         expect( HrrRbMount.mountpoint?(@persist_files[ns].path) ).to be true
                         expect( File.stat(@persist_files[ns].path).ino ).to eq after
-                      end
-                    }
+                      }
+                    end
                   end
                 end
               end


### PR DESCRIPTION
The PR updates unshare operation to support :fork option for PID namespace and its persistent bind-mount file.