### PR TITLE
namespace files information collector feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Usage
 
-hrr_rb_lxns provides unshare and setns wrappers.
+hrr_rb_lxns provides unshare and setns wrappers, and namespace files information collector.
 
 ### Unshare
 
@@ -108,6 +108,22 @@ HrrRbLxns.setns can associate namespaces using files which specify namespaces, i
 system "ip netns add ns0"
 # Then associate with the network namespace with specifying the file instead of pid.
 HrrRbLxns.setns HrrRbLxns::NETNET, nil, {network: "/run/netns/ns0"}
+```
+
+### Files
+
+HrrRbLxns.files Collects the caller process's or a specific process's namespace files information, which are the file path and its inode number.
+
+```ruby
+# Collects the caller process's namespace files information
+files = HrrRbLxns.files
+# Collects a specific process's namespace files information
+files = HrrRbLxns.files 12345
+
+# Then, paths and their inode numbers are accesible
+files.uts.path    # => "/proc/12345/ns/uts"
+files[:ipc].ino   # => 4026531839
+files["net"].ino  # => 4026531840
 ```
 
 ## Note

--- a/lib/hrr_rb_lxns.rb
+++ b/lib/hrr_rb_lxns.rb
@@ -1,5 +1,6 @@
 require "hrr_rb_lxns/version"
 require "hrr_rb_lxns/hrr_rb_lxns"
+require "hrr_rb_lxns/files"
 require "hrr_rb_mount"
 
 # Utilities working with Linux namespaces for CRuby.
@@ -7,6 +8,20 @@ module HrrRbLxns
 
   # Constants that represent the flags for Linux namespaces operations.
   module Constants
+  end
+
+  # Collects namespace files information in /proc/PID/ns/ directory of a process.
+  #
+  # @example
+  #   # Collects the caller process's or a specific process's namespace files information
+  #   files = HrrRbLxns.files
+  #   files = HrrRbLxns.files 12345
+  #   files.uts.path # => "/proc/12345/ns/uts"
+  #
+  # @param pid [Integer] The pid of a process to collect namespace files information. If nil, uses the caller process's pid.
+  # @return [HrrRbLxns::Files]
+  def self.files pid=nil
+    Files.new pid
   end
 
   # A wrapper around unshare(2) system call.

--- a/lib/hrr_rb_lxns/files.rb
+++ b/lib/hrr_rb_lxns/files.rb
@@ -1,0 +1,131 @@
+module HrrRbLxns
+
+  # Represents namespace files information in /proc/PID/ns/ directory of a process.
+  #
+  # @example
+  #   # Collects the caller process's or a specific process's namespace files information
+  #   files = HrrRbLxns::Files.new
+  #   files = HrrRbLxns::Files.new 12345
+  #
+  #   # Each namespace file is accessible as a method or a Hash-like key
+  #   files.uts.path    # => "/proc/12345/ns/uts"
+  #   files[:uts].path  # => "/proc/12345/ns/uts"
+  #   files["uts"].path # => "/proc/12345/ns/uts"
+  class Files
+    include Enumerable
+
+    # Returns the file information of attribute :mnt.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :mnt
+
+    # Returns the file information of attribute :uts.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :uts
+
+    # Returns the file information of attribute :ipc.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :ipc
+
+    # Returns the file information of attribute :net.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :net
+
+    # Returns the file information of attribute :pid.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :pid
+
+    # Returns the file information of attribute :pid_for_children.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :pid_for_children
+
+    # Returns the file information of attribute :user.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :user
+
+    # Returns the file information of attribute :cgroup.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :cgroup
+
+    # Returns the file information of attribute :time.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :time
+
+    # Returns the file information of attribute :time_for_children.
+    #
+    # @return [HrrRbLxns::Files::File]
+    #
+    attr_reader :time_for_children
+
+    # @param pid [Integer] The pid of a process to collect namespace files information. If nil, uses the caller process's pid.
+    #
+    def initialize pid=nil
+      pid ||= Process.pid
+      @mnt               = File.new "/proc/#{pid}/ns/mnt"
+      @uts               = File.new "/proc/#{pid}/ns/uts"
+      @ipc               = File.new "/proc/#{pid}/ns/ipc"
+      @net               = File.new "/proc/#{pid}/ns/net"
+      @pid               = File.new "/proc/#{pid}/ns/pid"
+      @pid_for_children  = File.new "/proc/#{pid}/ns/pid_for_children"
+      @user              = File.new "/proc/#{pid}/ns/user"
+      @cgroup            = File.new "/proc/#{pid}/ns/cgroup"
+      @time              = File.new "/proc/#{pid}/ns/time"
+      @time_for_children = File.new "/proc/#{pid}/ns/time_for_children"
+    end
+
+    # Returns the file information of the specified key.
+    #
+    # @example
+    #   files = HrrRbLxns::Files.new 12345
+    #   files[:uts].path  # => "/proc/12345/ns/uts"
+    #   files["uts"].path # => "/proc/12345/ns/uts"
+    #
+    # @param key [Symbol,String] The namespace file name, which is :mnt, :uts, pid, :pid_for_children, ....
+    # @return [HrrRbLxns::Files::File]
+    #
+    def [] key
+      __send__ key
+    end
+
+    # Calls the given block once for each key with associated file information.
+    # If no block is given, an Enumerator is returned.
+    #
+    # @example
+    #   files = HrrRbLxns::Files.new 12345
+    #   files.each do |type, namespace_file|
+    #     # at first iteration
+    #     type                # => :cgroup
+    #     namespace_file.path # => "/proc/12345/ns/cgroup"
+    #   end
+    #
+    def each
+      keys_with_files = [:mnt, :uts, :ipc, :net, :pid, :pid_for_children, :user, :cgroup, :time, :time_for_children].map{ |key| [key, __send__(key)] }
+      if block_given?
+        keys_with_files.each do |kv|
+          yield kv
+        end
+      else
+        keys_with_files.each
+      end
+    end
+  end
+end
+
+require "hrr_rb_lxns/files/file"

--- a/lib/hrr_rb_lxns/files/file.rb
+++ b/lib/hrr_rb_lxns/files/file.rb
@@ -1,0 +1,33 @@
+module HrrRbLxns
+  class Files
+
+    # A class that takes a path to a namespace file and collects then keeps its inode.
+    #
+    # @example
+    #   file = HrrRbLxns::Files::File.new "/proc/12345/ns/uts"
+    #   file.path # => "/proc/12345/ns/uts"
+    #   file.ino  # => 4026531839
+    #
+    class File
+
+      # Returns the file information of attribute :path.
+      #
+      # @return [String] The path to the namespace file.
+      #
+      attr_reader :path
+
+      # Returns the file information of attribute :ino.
+      #
+      # @return [Integer,nil] The inode number of the namespace file. If the path is not valid, then ino is nil.
+      #
+      attr_reader :ino
+
+      # @param path [String] The path to a namespace file.
+      #
+      def initialize path
+        @path = path
+        @ino  = ::File.exist?(path) ? ::File.stat(path).ino : nil
+      end
+    end
+  end
+end

--- a/spec/hrr_rb_lxns/files/file_spec.rb
+++ b/spec/hrr_rb_lxns/files/file_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe HrrRbLxns::Files::File do
+  context "with valid namespace file path" do
+    let(:path){ "/proc/self/ns/net" }
+
+    it "takes the path to the namespace file and collects then keeps its inode" do
+      file = described_class.new path
+
+      expect( file.path ).to eq path
+      expect( file.ino ).to be > 0
+    end
+  end
+
+  context "with invalid (not exist) namespace file path" do
+    let(:path){ "/proc/self/ns/does_not_exist" }
+
+    it "keeps nil as inode number for the path" do
+      file = described_class.new path
+
+      expect( file.path ).to eq path
+      expect( file.ino ).to be nil
+    end
+  end
+end
+

--- a/spec/hrr_rb_lxns/files_spec.rb
+++ b/spec/hrr_rb_lxns/files_spec.rb
@@ -1,0 +1,125 @@
+RSpec.describe HrrRbLxns::Files do
+  it "includes Enumerable module" do
+    expect(HrrRbLxns::Files.ancestors).to include ::Enumerable
+  end
+
+  context "with no pid specified" do
+    let(:pid){ Process.pid }
+
+    it "returns the namespace files information of the current process" do
+      files = described_class.new
+
+      file = "/proc/#{pid}/ns/mnt";               expect( files.mnt.path               ).to eq file
+      file = "/proc/#{pid}/ns/uts";               expect( files.uts.path               ).to eq file
+      file = "/proc/#{pid}/ns/ipc";               expect( files.ipc.path               ).to eq file
+      file = "/proc/#{pid}/ns/net";               expect( files.net.path               ).to eq file
+      file = "/proc/#{pid}/ns/pid";               expect( files.pid.path               ).to eq file
+      file = "/proc/#{pid}/ns/pid_for_children";  expect( files.pid_for_children.path  ).to eq file
+      file = "/proc/#{pid}/ns/user";              expect( files.user.path              ).to eq file
+      file = "/proc/#{pid}/ns/cgroup";            expect( files.cgroup.path            ).to eq file
+      file = "/proc/#{pid}/ns/time";              expect( files.time.path              ).to eq file
+      file = "/proc/#{pid}/ns/time_for_children"; expect( files.time_for_children.path ).to eq file
+
+      file = "/proc/#{pid}/ns/mnt";               expect( files.mnt.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/uts";               expect( files.uts.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/ipc";               expect( files.ipc.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/net";               expect( files.net.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/pid";               expect( files.pid.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/pid_for_children";  expect( files.pid_for_children.ino  ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/user";              expect( files.user.ino              ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/cgroup";            expect( files.cgroup.ino            ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/time";              expect( files.time.ino              ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/time_for_children"; expect( files.time_for_children.ino ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+
+      expect( files[:mnt]               ).to be files.mnt
+      expect( files[:uts]               ).to be files.uts
+      expect( files[:ipc]               ).to be files.ipc
+      expect( files[:net]               ).to be files.net
+      expect( files[:pid]               ).to be files.pid
+      expect( files[:pid_for_children]  ).to be files.pid_for_children
+      expect( files[:user]              ).to be files.user
+      expect( files[:cgroup]            ).to be files.cgroup
+      expect( files[:time]              ).to be files.time
+      expect( files[:time_for_children] ).to be files.time_for_children
+
+      expect( files["mnt"]               ).to be files.mnt
+      expect( files["uts"]               ).to be files.uts
+      expect( files["ipc"]               ).to be files.ipc
+      expect( files["net"]               ).to be files.net
+      expect( files["pid"]               ).to be files.pid
+      expect( files["pid_for_children"]  ).to be files.pid_for_children
+      expect( files["user"]              ).to be files.user
+      expect( files["cgroup"]            ).to be files.cgroup
+      expect( files["time"]              ).to be files.time
+      expect( files["time_for_children"] ).to be files.time_for_children
+    end
+  end
+
+  context "with pid specified" do
+    let(:pid){ Process.ppid }
+
+    it "returns the namespace files information of the specified process" do
+      files = described_class.new pid
+
+      file = "/proc/#{pid}/ns/mnt";               expect( files.mnt.path               ).to eq file
+      file = "/proc/#{pid}/ns/uts";               expect( files.uts.path               ).to eq file
+      file = "/proc/#{pid}/ns/ipc";               expect( files.ipc.path               ).to eq file
+      file = "/proc/#{pid}/ns/net";               expect( files.net.path               ).to eq file
+      file = "/proc/#{pid}/ns/pid";               expect( files.pid.path               ).to eq file
+      file = "/proc/#{pid}/ns/pid_for_children";  expect( files.pid_for_children.path  ).to eq file
+      file = "/proc/#{pid}/ns/user";              expect( files.user.path              ).to eq file
+      file = "/proc/#{pid}/ns/cgroup";            expect( files.cgroup.path            ).to eq file
+      file = "/proc/#{pid}/ns/time";              expect( files.time.path              ).to eq file
+      file = "/proc/#{pid}/ns/time_for_children"; expect( files.time_for_children.path ).to eq file
+
+      file = "/proc/#{pid}/ns/mnt";               expect( files.mnt.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/uts";               expect( files.uts.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/ipc";               expect( files.ipc.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/net";               expect( files.net.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/pid";               expect( files.pid.ino               ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/pid_for_children";  expect( files.pid_for_children.ino  ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/user";              expect( files.user.ino              ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/cgroup";            expect( files.cgroup.ino            ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/time";              expect( files.time.ino              ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+      file = "/proc/#{pid}/ns/time_for_children"; expect( files.time_for_children.ino ).to eq (File.exist?(file) ? File.stat(file).ino : nil)
+
+      expect( files[:mnt]               ).to be files.mnt
+      expect( files[:uts]               ).to be files.uts
+      expect( files[:ipc]               ).to be files.ipc
+      expect( files[:net]               ).to be files.net
+      expect( files[:pid]               ).to be files.pid
+      expect( files[:pid_for_children]  ).to be files.pid_for_children
+      expect( files[:user]              ).to be files.user
+      expect( files[:cgroup]            ).to be files.cgroup
+      expect( files[:time]              ).to be files.time
+      expect( files[:time_for_children] ).to be files.time_for_children
+
+      expect( files["mnt"]               ).to be files.mnt
+      expect( files["uts"]               ).to be files.uts
+      expect( files["ipc"]               ).to be files.ipc
+      expect( files["net"]               ).to be files.net
+      expect( files["pid"]               ).to be files.pid
+      expect( files["pid_for_children"]  ).to be files.pid_for_children
+      expect( files["user"]              ).to be files.user
+      expect( files["cgroup"]            ).to be files.cgroup
+      expect( files["time"]              ).to be files.time
+      expect( files["time_for_children"] ).to be files.time_for_children
+    end
+  end
+
+  describe "#each" do
+    let(:keys){ [:mnt, :uts, :ipc, :net, :pid, :pid_for_children, :user, :cgroup, :time, :time_for_children] }
+    let(:pid){ Process.pid }
+
+    it "iterates for each namespace file" do
+      files = described_class.new
+
+      expect( files.each ).to be_an_instance_of ::Enumerator
+
+      files.each do |file|
+        expect( keys.include? file[0] ).to be true
+        expect( file[1] ).to be_an_instance_of HrrRbLxns::Files::File
+      end
+    end
+  end
+end


### PR DESCRIPTION
HrrRbLxns.files Collects the caller process's or a specific process's namespace files information, which are the file path and its inode number.

```ruby
# Collects the caller process's namespace files information
files = HrrRbLxns.files
# Collects a specific process's namespace files information
files = HrrRbLxns.files 12345
# Then, paths and their inode numbers are accesible
files.uts.path    # => "/proc/12345/ns/uts"
files[:ipc].ino   # => 4026531839
files["net"].ino  # => 4026531840
```