### PR TITLE
Feature monotonic and boottime offsets for time namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ File.read("/proc/self/setgroups")                     # => "deny\n"
 File.read("/proc/self/gid_map").gsub(/ +/, " ")       # => " 0 0 1\n"
 ```
 
+Time namespace provides per-namespace monotonic and boottime clocks. The clock offsets can be set by `:monotonic` and `:boottime` options.
+
+```ruby
+options = {:monotonic => 123.456, :boottime => "123.456"}
+HrrRbLxns.unshare HrrRbLxns::NEWTIME, options          # => 0
+File.read("/proc/self/timens_offsets").gsub(/ +/, " ") # => "monotonic 123 456000000\nboottime 123 456000000\n"
+```
+
 ### Setns
 
 HrrRbLxns.setns method wraps around setns(2) system call. The system call associate the caller process's namespace to an existing one, which is disassociated by some other process.

--- a/ext/hrr_rb_lxns/hrr_rb_lxns.c
+++ b/ext/hrr_rb_lxns/hrr_rb_lxns.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE 1
 #include <sched.h>
 #include <linux/version.h>
+#include <time.h>
 
 VALUE rb_mHrrRbLxns;
 VALUE rb_mHrrRbLxnsConst;
@@ -116,5 +117,13 @@ Init_hrr_rb_lxns(void)
 #ifdef CLONE_NEWTIME
   /* Represents time namespace. */
   rb_define_const(rb_mHrrRbLxnsConst, "NEWTIME", INT2FIX(CLONE_NEWTIME));
+#endif
+#ifdef CLOCK_MONOTONIC
+  /* Represents monotonic clock. */
+  rb_define_const(rb_mHrrRbLxnsConst, "MONOTONIC", INT2FIX(CLOCK_MONOTONIC));
+#endif
+#ifdef CLOCK_BOOTTIME
+  /* Represents boottime clock. */
+  rb_define_const(rb_mHrrRbLxnsConst, "BOOTTIME", INT2FIX(CLOCK_BOOTTIME));
 #endif
 }


### PR DESCRIPTION
This PR implements :monotonic and :boottime options in .unshare method for time namespace.